### PR TITLE
Refactor and update for macro 1.1 semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ proc-macro = true
 test = false
 
 [dependencies]
-log = "0.3.6"
-syn = "0.9.0"
-quote = "0.3.3"
+proc-macro2 = "0.4"
+syn = "0.15"
+quote = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accessors"
-version = "0.0.3"
+version = "0.1.3"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 
 description = "(WIP) Getters and setters for Rust using macros 1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accessors"
-version = "0.1.3"
+version = "0.1.0"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 
 description = "(WIP) Getters and setters for Rust using macros 1.1"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,16 +1,16 @@
-#![feature(proc_macro)]
-
 #[macro_use]
 extern crate accessors;
 
 #[derive(getters, setters)]
-#[setters(into)]
 struct Simple {
+    #[setter(into)]
     field: String,
 }
 
 fn main() {
-    let mut s = Simple { field: "hello".to_owned() };
+    let mut s = Simple {
+        field: "hello".to_owned(),
+    };
     println!("{}", s.field());
     s.set_field("there");
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,13 +4,18 @@ extern crate accessors;
 #[derive(getters, setters)]
 struct Simple {
     #[setter(into)]
-    field: String,
+    field_a: String,
+    #[setter(into = true)]
+    field_b: String,
 }
 
 fn main() {
     let mut s = Simple {
-        field: "hello".to_owned(),
+        field_a: "hello".to_owned(),
+        field_b: "world".to_owned(),
     };
-    println!("{}", s.field());
-    s.set_field("there");
+
+    println!("{}", s.field_a());
+    s.set_field_a("hi");
+    s.set_field_b("there");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl GetterConfig {
 
 fn extract_bool(lit: &Lit) -> bool {
     if let Lit::Bool(LitBool { value, .. }) = lit {
-        value.clone()
+        *value
     } else {
         panic!("Expected bool");
     }


### PR DESCRIPTION
I couldn't figure out how to preserve the `#[setters]` attribute in its existing form as rustc always ends up complaining that `'setters' is a derive mode`, so I rewrote it as a per-field attribute which should be easily extendable with other per-field settings.

Other notes:
- Fixes #1 
- Fixes #6
- Bumped `syn`, `quote` and `proc_macro` versions
- Applied `rustfmt` and `clippy` to everything
- Bumped version to `0.1.0` due to breaking changes
